### PR TITLE
Escaping % characters in request path.

### DIFF
--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -313,6 +313,7 @@ class AWS4Auth(AuthBase):
         if path.endswith('/') and not fixed_path.endswith('/'):
             fixed_path += '/'
         full_path = fixed_path
+        full_path = quote(full_path, safe='~@#$&()*!+=:;,.?/\'')
         if qs:
             full_path = '?'.join((full_path, qs))
         return full_path


### PR DESCRIPTION
I am running into an issue where I still get the mismatched signature from AWS ES. The request looks like this:

PUT /products/product/foo%3A0234aa9d45c45284fbd3f5dde43e09fc95cf05dc

AWS says that it wants the canonical request to be:

PUT /products/product/foo%**25**3A0234aa9d45c45284fbd3f5dde43e09fc95cf05dc

Basically, it looks like we need to escape % characters in the path, not just in the query string.
